### PR TITLE
Corrected jQuery inclusion, Promise shimming, and first build instructions

### DIFF
--- a/ClientApp/boot.ts
+++ b/ClientApp/boot.ts
@@ -4,6 +4,11 @@ import 'bootstrap/dist/css/bootstrap.css';
 import 'bootstrap';
 declare const IS_DEV_BUILD: boolean; // The value is supplied by Webpack during the build
 
+import 'jquery';
+declare const $: JQueryStatic;
+(<any>window).jQuery = (<any>window).$ = $;
+
+
 export function configure(aurelia: Aurelia) {
   aurelia.use.standardConfiguration();
 

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Since this demo combines both .NET and Aurelia, you will need to install the dep
 
 * `dotnet restore` - This restores the .NET packages for the ASP.NET part of the application.
 * `npm install` - This restores the JavaScript packages that comprise Aurelia along with the related frontend build and development tooling, such as Webpack and TypeScript.
+* `webpack --config webpack.config.vendor.js` - This repackages all of your vendor dependencies, and only needs to be called if you change the vendor packages or update components
 
 ### Configuring Your Environment
 

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "todo",
   "version": "0.0.0",
   "dependencies": {
+    "@types/jquery": "^3.2.12",
     "aurelia-bootstrapper": "^2.0.1",
     "aurelia-fetch-client": "^1.0.1",
     "aurelia-framework": "^1.1.0",
@@ -9,6 +10,7 @@
     "aurelia-pal": "^1.3.0",
     "aurelia-router": "^1.2.1",
     "bootstrap": "^3.3.7",
+    "es6-promise": "^4.1.1",
     "isomorphic-fetch": "^2.2.1",
     "jquery": "^3.2.1"
   },

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -7,7 +7,7 @@ module.exports = (env) => {
     const isDevBuild = !(env && env.prod);
     return [{
         stats: { modules: false },
-        entry: { 'app': 'aurelia-bootstrapper' },
+        entry: { "app": ["es6-promise/auto", "aurelia-bootstrapper"] }, // Include automatic Promise shim for IE11
         resolve: {
             extensions: ['.ts', '.js'],
             modules: ['ClientApp', 'node_modules'],
@@ -26,6 +26,7 @@ module.exports = (env) => {
             ]
         },
         plugins: [
+            new webpack.ProvidePlugin({ $: 'jquery', jQuery: 'jquery' }), // Included to allow global creation of window.$ in boot.ts
             new webpack.DefinePlugin({ IS_DEV_BUILD: JSON.stringify(isDevBuild) }),
             new webpack.DllReferencePlugin({
                 context: __dirname,


### PR DESCRIPTION
- Corrected jQuery inclusion to make $ and jQuery globally available to HTML scripts. Also added typings for jQuery
- Added auto-ES6 shim for IE11 in packages and included in 'entry' section of webpack config
- Included vendor webpack instruction in README.MD